### PR TITLE
移出model和dataload

### DIFF
--- a/src/datamodule/baseline_datamodule.py
+++ b/src/datamodule/baseline_datamodule.py
@@ -1,64 +1,214 @@
+import numpy as np
+import pandas as pd
 import torch
 import logging
+import os
+import hashlib
 
 from omegaconf import OmegaConf
-from pytorch_lightning import LightningDataModule
-from src.data import TDCDataModule, get_task_dir
-from src.utils import get_featurizer
+import typing as T
+from torch.nn.utils.rnn import pad_sequence
+from torch.utils.data import DataLoader
+from torch.utils.data.sampler import WeightedRandomSampler
+
+from src.featurizers.protein import FOLDSEEK_MISSING_IDX
+from src.utils import get_featurizer, logg
+from src.datamodule.dg_datamodule import DGDataModule
+from src.datamodule.pre_encoded_datamodule import BinaryDataset
 
 
-class BaselineDataModule(LightningDataModule):
+
+def filter_max_segment(group):
+    category_counts = group['Y'].value_counts()
+    max_count = category_counts.max()
+    max_categories = category_counts[category_counts == max_count].index
+    if len(max_categories) > 1:
+        return pd.DataFrame(columns=group.columns)
+    max_category = max_categories[0]
+    return group[group['Y'] == max_category]
+
+def get_cache_path(base_path, bins, dataset_name):
+    bins_str = "_".join(map(str, bins))
+    bins_hash = hashlib.md5(bins_str.encode()).hexdigest()
+    cache_file = os.path.join(base_path, f"cache_{dataset_name}_{bins_hash}.csv")
+    return cache_file
+
+
+def subsection(df, bins: list, is_train_val: bool, dataset_name,base_path="."):
+    cache_path = get_cache_path(base_path, bins, dataset_name)
+
+    if os.path.exists(cache_path):
+        print(f"加载缓存文件: {cache_path}")
+        return pd.read_csv(cache_path)
+
+    print(f"未找到缓存文件，重新计算: {cache_path}")
+    df['Combine'] = df['Drug'] + '_' + df['Target']
+    bins.append(float(np.inf))
+    labels = list(range(len(bins) - 1))
+    df['Y'] = pd.cut(df['Y'], bins=bins, labels=labels, right=False)
+
+    if is_train_val:
+        if all(df.groupby('Combine')['Y'].nunique() == 1):
+            print("所有组合已在单一段，无需筛选。")
+        else:
+            df = df.groupby('Combine', group_keys=False).apply(filter_max_segment)
+            print("筛选完成。")
+    else:
+        print("不需要筛选")
+
+    df = df.drop(columns='Combine')
+    bins.pop()
+
+    df.to_csv(cache_path, index=False)
+    print(f"结果已缓存至: {cache_path}")
+    return df
+
+def regression(df,dataset_name, base_path="."):
+    cache_path = get_cache_path(base_path, ["regression"],dataset_name)
+    if os.path.exists(cache_path):
+        print(f"加载缓存文件: {cache_path}")
+        return pd.read_csv(cache_path)
+    print(f"未找到缓存文件，重新计算: {cache_path}")
+    df['Y'] = np.log(df['Y'])
+    df.to_csv(cache_path, index=False)
+    print(f"结果已缓存至: {cache_path}")
+    return df
+
+
+class BaselineDataModule(DGDataModule):
     def __init__(self, config: OmegaConf) -> None:
-        super().__init__()
+        super().__init__(config)
         self.logger = logging.getLogger("BaselineDataModule")
-        self.prepare_data_per_node = False
-        use_cuda = torch.cuda.is_available()
-        device = torch.device("cuda:0" if use_cuda else "cpu")
-        task_dir = get_task_dir(config.task)
-        if len(config.ds) > 0:
-            suffix_task_dir = task_dir.with_suffix(f".{config.ds}")
-            if suffix_task_dir.is_dir():
-                task_dir = suffix_task_dir
-            else:
-                self.logger.warn(f"Cannot find dataset {str(suffix_task_dir)}, fall back to {task_dir}")
         if config.model_architecture in (
             "MorganAttention",
         ):
-            attention = True
+            self.attention = True
         else:
-            attention = False
+            self.attention = False
 
-        drug_featurizer = get_featurizer(
-            config.drug_featurizer, save_dir=task_dir
+        self.drug_featurizer = get_featurizer(
+            config.drug_featurizer, save_dir=self._task_dir
         )
-        target_featurizer = get_featurizer(
-            config.target_featurizer, per_tok=attention, save_dir=task_dir
+        self.target_featurizer = get_featurizer(
+            config.target_featurizer, per_tok=self.attention, save_dir=self._task_dir
         )
+        self.weights = None
 
-        self.datamodule = TDCDataModule(
-            str(task_dir),
-            drug_featurizer,
-            target_featurizer,
-            device=device,
-            seed=config.replicate,
-            batch_size=config.batch_size,
-            shuffle=config.shuffle,
-            num_workers=config.num_workers,
-            classify=config.classify,
-            bins=config.bins,
-        )
+    def calculate_weights(self, label_dict, dataset):
+        arr = []
+        for label, count in label_dict.items():
+            weight = len(dataset) / count
+            arr.append(weight)
+        return arr
 
     def prepare_data(self):
-        self.datamodule.prepare_data()
+        self.prepare_featurizer(self.target_featurizer, self.all_targets)
+        self.prepare_featurizer(self.drug_featurizer, self.all_drugs)
 
     def setup(self, stage: str):
-        self.datamodule.setup()
+        self.setup_featurizer(self.target_featurizer, self.all_targets)
+        self.setup_featurizer(self.drug_featurizer, self.all_drugs)
+        dg_name = self._dg_data["name"]
+        self.df_train, self.df_val = self._dg_group.get_train_valid_split(
+            benchmark=dg_name, split_type="random", seed=self._seed
+        )
+
+        if self.classify:
+            self.df_train = subsection(self.df_train, self.bins, True,'train',self._data_dir)
+            self.df_val = subsection(self.df_val, self.bins, True,'val',self._data_dir)
+            self.df_test = subsection(self.df_test, self.bins, False,'test',self._data_dir)
+        else:
+            self.df_train = regression(self.df_train, 'train',self._data_dir)
+            self.df_val = regression(self.df_val, 'val',self._data_dir)
+            self.df_test = regression(self.df_test, 'test',self._data_dir)
+
+        label_counts = self.df_train[self._label_column].value_counts().to_dict()
+        weights = self.calculate_weights(label_counts, self.df_train)
+        self._weights = torch.DoubleTensor(weights)
+
+        self.sampler = WeightedRandomSampler(
+            self._weights, len(self.df_train), replacement=True
+        )
+
+        if stage == "fit" or stage is None:
+            self.train_data = BinaryDataset(
+                self.df_train[self._drug_column],
+                self.df_train[self._target_column],
+                self.df_train[self._label_column],
+                self.drug_featurizer,
+                self.target_featurizer,
+            )
+            self.val_data = BinaryDataset(
+                self.df_val[self._drug_column],
+                self.df_val[self._target_column],
+                self.df_val[self._label_column],
+                self.drug_featurizer,
+                self.target_featurizer,
+            )
+            self.test_data = BinaryDataset(
+                self.df_test[self._drug_column],
+                self.df_test[self._target_column],
+                self.df_test[self._label_column],
+                self.drug_featurizer,
+                self.target_featurizer,
+            )
+
+        if stage == "test" or stage is None:
+            self.test_data = BinaryDataset(
+                self.df_test[self._drug_column],
+                self.df_test[self._target_column],
+                self.df_test[self._label_column],
+                self.drug_featurizer,
+                self.target_featurizer,
+            )
+
+
+    def _collate_fn(self, args: T.Tuple[torch.Tensor, torch.Tensor, torch.Tensor]):
+        d_emb = [a[0] for a in args]
+        t_emb = [a[1] for a in args]
+        labs = [a[2] for a in args]
+
+        try:
+            drugs = torch.stack(d_emb, 0)
+        except Exception as e:
+            logg.error(f"Testing failed with exception {e}")
+            print(d_emb)
+
+        targets = pad_sequence(
+            t_emb, batch_first=True, padding_value=FOLDSEEK_MISSING_IDX
+        )
+
+        labels = torch.stack(labs, 0)
+
+        return drugs, targets, labels.to(torch.int64)
 
     def train_dataloader(self):
-        return self.datamodule.train_dataloader()
+        return DataLoader(
+            self.train_data,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            collate_fn=self._collate_fn,
+            pin_memory=True,
+            drop_last=True,
+            sampler=self.sampler
+        )
 
     def val_dataloader(self):
-        return self.datamodule.test_dataloader()
+        return DataLoader(
+            self.val_data,
+            batch_size=self.batch_size,
+            shuffle=self.shuffle,
+            num_workers=self.num_workers,
+            collate_fn=self._collate_fn,
+            pin_memory=True
+        )
 
     def test_dataloader(self):
-        return self.datamodule.test_dataloader()
+        return DataLoader(
+            self.test_data,
+            batch_size=self.batch_size,
+            shuffle=self.shuffle,
+            num_workers=self.num_workers,
+            collate_fn=self._collate_fn,
+            pin_memory=True
+        )

--- a/src/datamodule/dg_datamodule.py
+++ b/src/datamodule/dg_datamodule.py
@@ -31,8 +31,10 @@ class DGDataModule(LightningDataModule):
         self._data_dir = self._task_dir
         self._drug_column = "Drug"
         self._target_column = "Target"
-        self._label_column=config.label_column
+        self._label_column="Y"
         self._seed = config.replicate
+        self.classify = config.classify
+        self.bins = config.bins
         self.load_data()
 
     def load_data(self):

--- a/src/datamodule/morgan_chembert_datamodule.py
+++ b/src/datamodule/morgan_chembert_datamodule.py
@@ -2,56 +2,181 @@ import torch
 import logging
 
 from omegaconf import OmegaConf
-from pytorch_lightning import LightningDataModule
-from src.data import TDCDataModule_Double, get_task_dir
-from src.utils import get_featurizer
 
-class MorganChembertDataModule(LightningDataModule):
+import typing as T
+from torch.nn.utils.rnn import pad_sequence
+from torch.utils.data import DataLoader
+from torch.utils.data.sampler import WeightedRandomSampler
+
+from src.datamodule.baseline_datamodule import subsection, regression, BaselineDataModule
+from src.featurizers import Featurizer
+from src.featurizers.protein import FOLDSEEK_MISSING_IDX
+from src.utils import get_featurizer, logg
+from src.datamodule.dg_datamodule import DGDataModule
+from src.datamodule.pre_encoded_datamodule import BinaryDataset
+
+class BinaryDataset_Double(BinaryDataset):
+    def __init__(
+            self,
+            drugs,
+            targets,
+            labels,
+            drug_featurizer_one: Featurizer,
+            drug_featurizer_two: Featurizer,
+            target_featurizer: Featurizer,
+    ):
+        super().__init__(drugs, targets, labels, drug_featurizer_one, target_featurizer)
+
+        self.drug_featurizer_two = drug_featurizer_two
+
+    def __getitem__(self, i: int):
+        drug_one = self.drug_featurizer(self.drugs.iloc[i])
+        drug_two = self.drug_featurizer_two(self.drugs.iloc[i])
+        target = self.target_featurizer(self.targets.iloc[i])
+        label = torch.tensor(self.labels.iloc[i])
+        return drug_one, drug_two, target, label
+
+
+class MorganChembertDataModule(BaselineDataModule):
     def __init__(self, config: OmegaConf) -> None:
-        super().__init__()
+        super().__init__(config)
         self.logger = logging.getLogger("MorganChembertDataModule")
-        self.prepare_data_per_node = False
-        use_cuda = torch.cuda.is_available()
-        device = torch.device("cuda:0" if use_cuda else "cpu")
-        task_dir = get_task_dir(config.task)
-        if len(config.ds) > 0:
-            suffix_task_dir = task_dir.with_suffix(f".{config.ds}")
-            if suffix_task_dir.is_dir():
-                task_dir = suffix_task_dir
-            else:
-                self.logger.warn(f"Cannot find dataset {str(suffix_task_dir)}, fall back to {task_dir}")
-        drug_featurizer = get_featurizer(
-            config.drug_featurizer, save_dir=task_dir
-        )
-        target_featurizer = get_featurizer(
-            config.target_featurizer, per_tok=True, save_dir=task_dir
-        )
+        if config.model_architecture in (
+            "MorganChembertAttention",
+        ):
+            self.attention = True
+        else:
+            self.attention = False
 
-        self.datamodule = TDCDataModule_Double(
-            task_dir,
-            drug_featurizer,
-            target_featurizer,
-            device=device,
-            seed=config.replicate,
-            batch_size=config.batch_size,
-            shuffle=config.shuffle,
-            num_workers=config.num_workers,
-            classify=config.classify,
-            bins=config.bins,
-        )
-
+        self.drug_featurizer_two = self.drug_featurizer[1]
+        self.drug_featurizer = self.drug_featurizer[0]
     def prepare_data(self):
-        self.datamodule.prepare_data()
+        super(MorganChembertDataModule, self).prepare_data()
+        self.prepare_featurizer(self.drug_featurizer_two,self.all_drugs)
 
     def setup(self, stage: str):
-        self.datamodule.setup()
+        self.setup_featurizer(self.target_featurizer, self.all_targets)
+        self.setup_featurizer(self.drug_featurizer, self.all_drugs)
+        self.setup_featurizer(self.drug_featurizer_two,self.all_drugs)
+        dg_name = self._dg_data["name"]
+        self.df_train, self.df_val = self._dg_group.get_train_valid_split(
+            benchmark=dg_name, split_type="random", seed=self._seed
+        )
+
+        if self.classify:
+            self.df_train = subsection(self.df_train, self.bins, True,'train',self._data_dir)
+            self.df_val = subsection(self.df_val, self.bins, True,'val',self._data_dir)
+            self.df_test = subsection(self.df_test, self.bins, False,'test',self._data_dir)
+        else:
+            self.df_train = regression(self.df_train, 'train',self._data_dir)
+            self.df_val = regression(self.df_val, 'val',self._data_dir)
+            self.df_test = regression(self.df_test, 'test',self._data_dir)
+
+        label_counts = self.df_train[self._label_column].value_counts().to_dict()
+        weights = self.calculate_weights(label_counts, self.df_train)
+        self._weights = torch.DoubleTensor(weights)
+
+        self.sampler = WeightedRandomSampler(
+            self._weights, len(self.df_train), replacement=True
+        )
+
+        if stage == "fit" or stage is None:
+            self.train_data = BinaryDataset_Double(
+                self.df_train[self._drug_column],
+                self.df_train[self._target_column],
+                self.df_train[self._label_column],
+                self.drug_featurizer,
+                self.drug_featurizer_two,
+                self.target_featurizer,
+            )
+
+            self.val_data = BinaryDataset_Double(
+                self.df_val[self._drug_column],
+                self.df_val[self._target_column],
+                self.df_val[self._label_column],
+                self.drug_featurizer,
+                self.drug_featurizer_two,
+                self.target_featurizer,
+            )
+
+        if stage == "test" or stage is None:
+            self.test_data = BinaryDataset_Double(
+                self.df_test[self._drug_column],
+                self.df_test[self._target_column],
+                self.df_test[self._label_column],
+                self.drug_featurizer,
+                self.drug_featurizer_two,
+                self.target_featurizer,)
+
+        if stage == "test" or stage is None:
+            self.test_data = BinaryDataset_Double(
+                self.df_test[self._drug_column],
+                self.df_test[self._target_column],
+                self.df_test[self._label_column],
+                self.drug_featurizer,
+                self.drug_featurizer_two,
+                self.target_featurizer,)
+
+    def calculate_weights(self, label_dict, dataset):
+        arr = []
+        for label, count in label_dict.items():
+            weight = len(dataset) / count
+            arr.append(weight)
+        return arr
+
+    def _collate_fn(
+        self,args: T.Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
+    ):
+        d_emb_one = [a[0] for a in args]
+        d_emb_two = [a[1] for a in args]
+        t_emb = [a[2] for a in args]
+        labs = [a[3] for a in args]
+
+        # 堆叠药物特征
+        drugs_one = torch.stack(d_emb_one, 0)
+        drugs_two = torch.stack(d_emb_two, 0)
+
+        drugs = {
+            "drugs_one": drugs_one,
+            "drugs_two": drugs_two,
+        }
+
+        # 对靶标进行填充
+        targets = pad_sequence(t_emb, batch_first=True, padding_value=FOLDSEEK_MISSING_IDX)
+
+        labels = torch.stack(labs, 0)
+
+        return drugs, targets, labels.to(torch.int64)
 
     def train_dataloader(self):
-        return self.datamodule.train_dataloader()
+        return DataLoader(
+            self.train_data,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            collate_fn=self._collate_fn,
+            pin_memory=True,
+            drop_last=True,
+            sampler=self.sampler
+        )
 
     def val_dataloader(self):
-        return self.datamodule.test_dataloader()
-        return self.datamodule.val_dataloader()
+        return DataLoader(
+            self.val_data,
+            batch_size=self.batch_size,
+            shuffle=self.shuffle,
+            num_workers=self.num_workers,
+            collate_fn=self._collate_fn,
+            pin_memory=True
+        )
 
     def test_dataloader(self):
-        return self.datamodule.test_dataloader()
+        return DataLoader(
+            self.test_data,
+            batch_size=self.batch_size,
+            shuffle=self.shuffle,
+            num_workers=self.num_workers,
+            collate_fn=self._collate_fn,
+            pin_memory=True
+        )
+
+

--- a/src/models/base_model.py
+++ b/src/models/base_model.py
@@ -15,15 +15,17 @@ class BaseModelModule(pl.LightningModule):
         num_classes=2,
         loss_type="CE",
         lr=1e-4,
+        Ensemble_Learn = False,
     ):
         super().__init__()
-        self.drug_dim = drug_dim
-        self.target_dim = target_dim
-        self.latent_dim = latent_dim
+        self.drug_shape = drug_dim
+        self.target_shape = target_dim
+        self.latent_dimension = latent_dim
         self.classify = classify
         self.num_classes = num_classes
         self.loss_type = loss_type
         self.lr = lr
+        self.Ensemble_Learn = Ensemble_Learn
         self.init_metrics_and_loss()
 
     def init_metrics_and_loss(self):
@@ -39,6 +41,9 @@ class BaseModelModule(pl.LightningModule):
         else:
             if self.loss_type == "OR":
                 self.loss_fct = self.ordinal_regression_loss
+
+            elif self.loss_type=="CLM":
+                self.loss_fct = self.clm_loss
             else:
                 self.loss_fct = torch.nn.CrossEntropyLoss()
             self.metrics = {
@@ -60,21 +65,39 @@ class BaseModelModule(pl.LightningModule):
         loss = torch.nn.BCELoss()(y_pred, mask)
         return loss
 
-    def diff_ordinal_regression_loss(self, y_pred, y_target,factor=1):
-        num_thresholds = y_pred.size(1)
-        y_true_expanded = y_target.unsqueeze(1).repeat(1, num_thresholds)
-        mask = (torch.arange(num_thresholds).to(y_pred.device).unsqueeze(0) < y_true_expanded).float()
-        loss = torch.nn.BCELoss(reduction='none')(y_pred, mask)
-        rank_diff = torch.abs(torch.arange(num_thresholds).to(y_pred.device).unsqueeze(0) - y_true_expanded)
-        weight = (1 - mask) * (factor * rank_diff.float()) + mask
-        weighted_loss = (loss * weight).mean()
-        return weighted_loss
+    def clm_loss(self, y_pred, y_true):
+
+        eps = 1e-15
+        y_true = y_true.unsqueeze(dim=-1)
+        likelihoods = torch.clamp(torch.gather(y_pred, 1, y_true), eps, 1 - eps)
+        loss = -torch.log(likelihoods).mean()
+
+        return loss
 
     def ordinal_regression_predict(self, predict):
 
         predict = (predict > 0.5).sum(dim=1)
         predict = torch.nn.functional.one_hot(predict,num_classes=self.num_classes).to(torch.float32)
         return predict
+
+    def clm_predict(self, y_pred):
+        num_thresholds = y_pred.size(1)
+        mask = torch.arange(num_thresholds).to(y_pred.device).unsqueeze(0)
+        y_pred = torch.sum(y_pred * mask, dim=-1)
+        y_pred = torch.round(y_pred).to(torch.int64)
+        predict = torch.nn.functional.one_hot(y_pred,num_classes=num_thresholds).to(torch.float32)
+        print(predict.shape)
+        return predict
+
+    def save_to_txt(self,drug, target, label, pred, file_path):
+        drug = drug.cpu().numpy() if torch.is_tensor(drug) else drug
+        target = target.cpu().numpy() if torch.is_tensor(target) else target
+        label = label.cpu().numpy() if torch.is_tensor(label) else label
+        pred = pred.cpu().numpy() if torch.is_tensor(pred) else pred
+        with open(file_path, 'w') as f:
+            f.write("drug, target, label, pred\n")
+            for d, t, l, p in zip(drug, target, label, pred):
+                f.write(f"{d}, {t}, {l}, {p}\n")
 
     def forward(self, drug, target):
         raise NotImplementedError()
@@ -86,7 +109,4 @@ class BaseModelModule(pl.LightningModule):
         raise NotImplementedError()
 
     def validation_step(self, train_batch, batch_idx):
-        raise NotImplementedError()
-
-    def on_validation_epoch_end(self):
         raise NotImplementedError()

--- a/src/models/base_model.py
+++ b/src/models/base_model.py
@@ -70,6 +70,12 @@ class BaseModelModule(pl.LightningModule):
         weighted_loss = (loss * weight).mean()
         return weighted_loss
 
+    def ordinal_regression_predict(self, predict):
+
+        predict = (predict > 0.5).sum(dim=1)
+        predict = torch.nn.functional.one_hot(predict,num_classes=self.num_classes).to(torch.float32)
+        return predict
+
     def forward(self, drug, target):
         raise NotImplementedError()
 

--- a/src/models/morgan_chembert_model.py
+++ b/src/models/morgan_chembert_model.py
@@ -66,15 +66,4 @@ class MorganChembertAttention(MorganAttention):
         weight_one, weight_two = weights[0], weights[1]
 
         out_embedding = weight_one * out_embedding_one + weight_two * out_embedding_two
-        x = self.mlp(out_embedding)
-        if self.loss_type == 'OR' and self.Ensemble_Learn:
-            predict = [classifier(x) for classifier in self.predict_layer]
-            predict = torch.cat(predict, dim=1)
-        elif self.loss_type == 'CLM':
-            predict = self.predict_layer(x)
-            predict = self.link(predict)
-        else:
-            predict = self.predict_layer(x)
-
-        predict = torch.squeeze(predict, dim=-1)
-        return predict
+        return self.classifier_forward(out_embedding)

--- a/src/models/morgan_chembert_model.py
+++ b/src/models/morgan_chembert_model.py
@@ -1,67 +1,80 @@
-import numpy as np
 import torch
-from .base_model import BaseModelModule
-from src.architectures import DrugProteinAttention_Double
+from torch import nn
+from src.architectures import BertPooler
+from src.models.morgan_model import MorganAttention
+import torch.nn.functional as F
+import logging
+import time
+log_filename = f"log_MorganChembert.txt"
+logging.basicConfig(filename=log_filename, level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-class MorganChembertAttention(BaseModelModule):
+
+class MorganChembertAttention(MorganAttention):
     def __init__(
         self,
-        drug_dim=384,
+        drug_dim=2048,
+        drug_dim_two=384,
         target_dim=1024,
         latent_dim=1024,
         classify=True,
         num_classes=2,
         loss_type="CE",
         lr=1e-4,
+        Ensemble_Learn = False,
         lr_t0=10,
     ):
         super().__init__(
-            drug_dim, target_dim, latent_dim, classify, num_classes, loss_type, lr
+            drug_dim, target_dim, latent_dim, classify, num_classes, loss_type, lr , Ensemble_Learn,lr_t0
         )
-        self.model = DrugProteinAttention_Double(
-            latent_dimension=latent_dim,
-            classify=classify,
-            num_classes=num_classes,
-            loss_type=loss_type,
+        self.drug_shape_two = drug_dim_two
+        self.pooler_two = BertPooler(self.latent_dimension)
+        self.drug_projector_two = nn.Sequential(
+            nn.Linear(self.drug_shape_two, self.latent_dimension)
         )
-        self.lr_t0 = lr_t0
-        self.validation_step_outputs = []
+        self.input_norm_two = nn.LayerNorm(self.latent_dimension)
+        encoder_layer_two = nn.TransformerEncoderLayer(d_model=self.latent_dimension, nhead=16, batch_first=True)
+        self.transformer_encoder_two = nn.TransformerEncoder(encoder_layer_two, num_layers=1)
 
-    def forward(self, drug, target,is_train=True):
-        return self.model(drug['drugs_one'], drug['drugs_two'], target,is_train=is_train)
+        self.weight_one = nn.Parameter(torch.tensor(0.5, requires_grad=True))
+        self.weight_two = nn.Parameter(torch.tensor(0.5, requires_grad=True))
 
-    def configure_optimizers(self):
-        optimizer = torch.optim.AdamW(self.model.parameters(), lr=self.lr)
-        lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
-            optimizer, T_0=self.lr_t0
-        )
-        return [optimizer], [{"scheduler": lr_scheduler, "interval": "epoch"}]
+    def forward(self,
+                drug: torch.Tensor,
+                target: torch.Tensor,):
 
-    def training_step(self, train_batch, batch_idx):
-        drug, target, label = train_batch  # target is (D + N_pool)
-        pred = self.forward(drug, target,True)
-        loss = self.loss_fct(pred, label.to(torch.float32))
-        self.log("train/loss", loss)
-        return loss
+        drug_projection_one = self.drug_projector(drug['drugs_one'])
+        drug_projection_two = self.drug_projector_two(drug['drugs_two'])
+        target_projection = target
 
-    def validation_step(self, train_batch, batch_idx):
-        drug, target, label = train_batch  # target is (D + N_pool)
-        pred = self.forward(drug, target,False)
-        loss = self.loss_fct(pred, label.to(torch.float32))
-        self.log("val/loss", loss)
-        result = {"loss": loss, "preds": pred, "target": label}
-        self.validation_step_outputs.append(result)
-        return result
+        drug_projection_one = drug_projection_one.unsqueeze(1)
+        drug_projection_two = drug_projection_two.unsqueeze(1)
+        input_one = torch.concat([drug_projection_one, target_projection], dim=1)
+        input_two = torch.concat([drug_projection_two, target_projection], dim=1)
 
-    def on_validation_epoch_end(self):
-        avg_loss = torch.stack([x["loss"] for x in self.validation_step_outputs]).mean()
-        preds = torch.concat([x["preds"] for x in self.validation_step_outputs])
-        target = torch.concat([x["target"] for x in self.validation_step_outputs])
-        self.print(f"*****Epoch {self.current_epoch}*****")
-        self.print(f"loss:{avg_loss}")
-        for name, metric in self.metrics.items():
-            value = metric(preds, target)
-            if np.isscalar(value):
-                self.log(f"val/{name}", value)
-            self.print(f"val/{name}: {value}")
-        self.validation_step_outputs.clear()
+        input_one = self.input_norm(input_one)
+        input_two = self.input_norm_two(input_two)
+
+        att_mask = self.get_att_mask(target)
+
+        output_one = self.transformer_encoder(input_one, src_key_padding_mask=att_mask)
+        output_two = self.transformer_encoder_two(input_two, src_key_padding_mask=att_mask)
+
+        out_embedding_one = self.pooler(output_one)
+        out_embedding_two = self.pooler_two(output_two)
+
+        weights = F.softmax(torch.stack([self.weight_one, self.weight_two]), dim=0)
+        weight_one, weight_two = weights[0], weights[1]
+
+        out_embedding = weight_one * out_embedding_one + weight_two * out_embedding_two
+        x = self.mlp(out_embedding)
+        if self.loss_type == 'OR' and self.Ensemble_Learn:
+            predict = [classifier(x) for classifier in self.predict_layer]
+            predict = torch.cat(predict, dim=1)
+        elif self.loss_type == 'CLM':
+            predict = self.predict_layer(x)
+            predict = self.link(predict)
+        else:
+            predict = self.predict_layer(x)
+
+        predict = torch.squeeze(predict, dim=-1)
+        return predict

--- a/src/models/morgan_model.py
+++ b/src/models/morgan_model.py
@@ -1,10 +1,14 @@
 import numpy as np
 import torch
-from torch.nn.parallel import DistributedDataParallel as DDP
+from spacecutter.models import LogisticCumulativeLink
+from torch import nn
 from .base_model import BaseModelModule
-from src.architectures import DrugProteinAttention
+from src.architectures import BertPooler, MLP
 import logging
-logging.basicConfig(filename='val.txt', level=logging.INFO, format='%(asctime)s - %(message)s')
+import time
+log_filename = f"log_Morgan.txt"
+logging.basicConfig(filename=log_filename, level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
 
 class MorganAttention(BaseModelModule):
     def __init__(
@@ -13,30 +17,132 @@ class MorganAttention(BaseModelModule):
         target_dim=1024,
         latent_dim=1024,
         classify=True,
-        num_classes=52,
-        loss_type="OR",
+        num_classes=24,
+        loss_type="CLM",
         lr=1e-4,
+        Ensemble_Learn=False,
         lr_t0=10,
     ):
         super().__init__(
-            drug_dim, target_dim, latent_dim, classify, num_classes, loss_type, lr
-        )
-        self.model = DrugProteinAttention(
-            drug_dim,
-            target_dim,
-            latent_dim,
-            classify=classify,
-            num_classes=num_classes,
-            loss_type=loss_type,
+            drug_dim, target_dim, latent_dim, classify, num_classes, loss_type, lr,Ensemble_Learn
         )
         self.lr_t0 = lr_t0
         self.validation_step_outputs = []
+        self.pooler = BertPooler(self.latent_dimension)
 
-    def forward(self, drug, target,is_train=True):
-        return self.model(drug, target,is_train=is_train)
+        self.drug_projector = nn.Sequential(
+            nn.Linear(self.drug_shape, self.latent_dimension)
+        )
+        self.target_projector = nn.Sequential(
+            nn.Linear(self.target_shape, self.latent_dimension)
+        )
+        self.input_norm = nn.LayerNorm(self.latent_dimension)
+        encoder_layer = nn.TransformerEncoderLayer(d_model=self.latent_dimension, nhead=16, batch_first=True)
+        self.transformer_encoder = nn.TransformerEncoder(encoder_layer, num_layers=1)
+
+        self.mlp = MLP(self.latent_dimension, 512, 256)
+        self.link = LogisticCumulativeLink(self.num_classes)
+
+        if classify:
+            if self.num_classes == 2:
+                self.predict_layer = nn.Sequential(
+                    nn.Linear(256, 1, bias=True),
+                    nn.Sigmoid(),
+                )
+            else:
+                if self.loss_type == 'OR' :
+                    if self.Ensemble_Learn:
+                        self.predict_layer = nn.ModuleList([
+                            nn.Sequential(
+                                nn.Linear(256, 1, bias=True),
+                                nn.Dropout(0.1),
+                                nn.Sigmoid(),
+                            )
+                            for _ in range(self.num_classes - 1)
+                        ])
+                    else:
+                        self.predict_layer = nn.Sequential(
+                        nn.Linear(256, self.num_classes-1, bias=True),
+                        nn.Sigmoid(),
+                        )
+
+                elif self.loss_type == "CLM":
+                    self.predict_layer = nn.Sequential(
+                        nn.Linear(256, 1, bias=True),
+                    )
+                else:
+                    self.predict_layer = nn.Sequential(
+                        nn.Linear(256, num_classes, bias=True),
+                    )
+        else:
+            self.predict_layer = nn.Sequential(
+                nn.Linear(256, 1, bias=True),
+                nn.ReLU(),
+            )
+
+        self.apply(self._init_weights)
+
+    def _init_weights(self, module):
+        """Initialize the weights"""
+        if isinstance(module, nn.Linear):
+            torch.nn.init.xavier_normal_(module.weight.data)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            torch.nn.init.xavier_normal_(module.weight.data)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+        elif isinstance(module, nn.LayerNorm):
+            module.bias.data.zero_()
+            module.weight.data.fill_(1.0)
+
+    def get_att_mask(self, target: torch.Tensor):
+
+        b, n, d = target.shape
+
+        mask = torch.mean(target, dim=-1)
+        mask = torch.where(mask != 0.0, False, True)
+
+        drug_mask = torch.zeros(b, 1).to(mask.device)
+        drug_mask = torch.where(drug_mask == 0, False, True)
+        mask = torch.concat([drug_mask, mask], dim=1)
+        return mask
+
+    def forward(self, drug: torch.Tensor, target: torch.Tensor):
+
+        b, d = drug.shape
+
+        b, n, d = target.shape
+
+        drug_projection = self.drug_projector(drug)
+        drug_projection = torch.tanh(drug_projection)
+        target_projection = target
+
+        drug_projection = drug_projection.unsqueeze(1)
+        inputs = torch.concat([drug_projection, target_projection], dim=1)
+
+        inputs = self.input_norm(inputs)
+
+        att_mask = self.get_att_mask(target)
+
+        outputs = self.transformer_encoder(inputs, src_key_padding_mask=att_mask)
+        out_embedding = self.pooler(outputs)
+
+        x = self.mlp(out_embedding)
+        if self.loss_type == 'OR' and self.Ensemble_Learn:
+            predict = [classifier(x) for classifier in self.predict_layer]
+            predict = torch.cat(predict, dim=1)
+        elif self.loss_type == 'CLM':
+            predict = self.predict_layer(x)
+            predict = self.link(predict)
+        else:
+            predict = self.predict_layer(x)
+
+        predict = torch.squeeze(predict, dim=-1)
+        return predict
 
     def configure_optimizers(self):
-        optimizer = torch.optim.AdamW(self.model.parameters(), lr=self.lr)
+        optimizer = torch.optim.AdamW(self.parameters(), lr=self.lr)
         lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
             optimizer, T_0=self.lr_t0
         )
@@ -45,19 +151,23 @@ class MorganAttention(BaseModelModule):
     def training_step(self, train_batch, batch_idx):
         drug, target, label = train_batch  # target is (D + N_pool)
         pred = self.forward(drug, target)
-        loss = self.loss_fct(pred, label.to(torch.float32))
+        loss = self.loss_fct(pred, label)
         self.log("train/loss", loss)
         return loss
 
     def validation_step(self, train_batch, batch_idx):
         drug, target, label = train_batch  # target is (D + N_pool)
         pred = self.forward(drug, target)
-        loss = self.loss_fct(pred, label.to(torch.float32))
+        loss = self.loss_fct(pred, label)
         self.log("val/loss", loss)
+        self.save_to_txt(drug, target, label, pred, file_path="result_before.txt")
         if self.loss_type=="OR":
             pred = self.ordinal_regression_predict(pred)
+        elif self.loss_type=='CLM':
+            pred = self.clm_predict(pred)
         else:
             pred = pred
+        self.save_to_txt(drug, target, label, pred, file_path="result_after.txt")
         result = {"loss": loss, "preds": pred, "target": label}
         self.validation_step_outputs.append(result)
         return result
@@ -78,7 +188,7 @@ class MorganAttention(BaseModelModule):
             logging.info(f"val/{name}: {value}")
             if name == "ConfusionMatrix":
                 confusion_matrix_np = value.cpu().numpy()
-                np.savetxt("confusion_matrix.csv", confusion_matrix_np, delimiter=",", fmt="%d")
+                np.savetxt(f"confusion_matrix.csv", confusion_matrix_np, delimiter=",", fmt="%d")
             self.print(f"val/{name}: {value}")
         self.validation_step_outputs.clear()
 

--- a/src/models/morgan_model.py
+++ b/src/models/morgan_model.py
@@ -44,19 +44,20 @@ class MorganAttention(BaseModelModule):
 
     def training_step(self, train_batch, batch_idx):
         drug, target, label = train_batch  # target is (D + N_pool)
-        pred = self.forward(drug, target,True)
+        pred = self.forward(drug, target)
         loss = self.loss_fct(pred, label.to(torch.float32))
         self.log("train/loss", loss)
         return loss
 
-
-
     def validation_step(self, train_batch, batch_idx):
-        print(f"Running on GPU {self.global_rank}")  # 确保每个 GPU 都在参与验证
         drug, target, label = train_batch  # target is (D + N_pool)
-        pred = self.forward(drug, target, False)
+        pred = self.forward(drug, target)
         loss = self.loss_fct(pred, label.to(torch.float32))
         self.log("val/loss", loss)
+        if self.loss_type=="OR":
+            pred = self.ordinal_regression_predict(pred)
+        else:
+            pred = pred
         result = {"loss": loss, "preds": pred, "target": label}
         self.validation_step_outputs.append(result)
         return result

--- a/train.py
+++ b/train.py
@@ -19,6 +19,7 @@ from omegaconf import OmegaConf
 from src.models.drug_target_attention import DrugTargetAttention
 from src.datamodule.pre_encoded_datamodule import PreEncodedDataModule
 from src.datamodule.finetune_chembert_datamodule import FineTuneChemBertDataModule
+from src.datamodule.morgan_chembert_datamodule import MorganChembertDataModule
 
 
 def init_config() -> OmegaConf:
@@ -66,10 +67,12 @@ if __name__ == "__main__":
         dm = BaselineDataModule(config)
     if config.model_architecture == "MorganAttention":
         model = MorganAttention(
+            drug_dim=config.drug_shape,
             latent_dim=config.latent_dimension,
             classify=config.classify,
             num_classes=config.num_classes,
-            loss_type=config.loss_type
+            loss_type=config.loss_type,
+            Ensemble_Learn=False,
         )
         # model = MorganAttention.load_from_checkpoint(config.checkpoint_path)
         dm = BaselineDataModule(config)
@@ -78,7 +81,8 @@ if __name__ == "__main__":
             latent_dim=config.latent_dimension,
             classify=config.classify,
             num_classes=config.num_classes,
-            loss_type=config.loss_type
+            loss_type=config.loss_type,
+            Ensemble_Learn=False,
         )
         dm = MorganChembertDataModule(config)
     if config.model_architecture == "DrugTargetAttention":


### PR DESCRIPTION
1.baselint_datamodule.py 添加缓存和移出分段逻辑 合并TDCdataload的功能
2.dg_datamodule.py 作为基类 添加bins和classify属性
3.morgan_chembert_datmodule.py 继承baseline_datamodule.py的类
  实现同时加载morgan和chembert的功能 合并了TDCdataload_double的功能
4.base_model.py 完善一些细节 加入了CLM:loss和predict
5.morgan_model.py 实现了原本DrugAttentionmodel的功能
6.morgan_chembert_model,py 继承morganmodel
  实现了DrugAttnetionmodel_Double的功能 用于morgan
  chembert同时加载的模型
7.train.py 对于morgan_model
  需要传入drug_shape由于morgan还是chembert的不同，加入Ensemble_Learn参数来选择分类头个数